### PR TITLE
Optimize growing performance by sorting candidate objects in-DB

### DIFF
--- a/migrations/versions/762c3a983d96_.py
+++ b/migrations/versions/762c3a983d96_.py
@@ -1,0 +1,27 @@
+"""Store vectors as CUBE points
+
+Revision ID: 762c3a983d96
+Revises: fe6fec6b70a6
+Create Date: 2021-10-28 08:59:45.382312
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from morphocluster.sql.types import Point
+from sqlalchemy.types import LargeBinary
+
+# revision identifiers, used by Alembic.
+revision = "762c3a983d96"
+down_revision = "fe6fec6b70a6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column("objects", "vector")
+    op.add_column("objects", sa.Column("vector", Point(numpy=True), nullable=True))
+
+
+def downgrade():
+    op.drop_column("objects", "vector")
+    sa.Column("vector", LargeBinary, autoincrement=False, nullable=True),

--- a/morphocluster/models.py
+++ b/morphocluster/models.py
@@ -19,66 +19,10 @@ from sqlalchemy.types import (
     PickleType,
     String,
     Text,
-    TypeEngine,
-    UserDefinedType,
 )
 
 from morphocluster.extensions import database as db
-
-
-class Point(UserDefinedType):
-    """
-    Represent a point by using a zero-volume cube from the cube extension.
-
-    This allows to calculate distances inside the database.
-
-    https://www.postgresql.org/docs/current/cube.html
-    """
-
-    def __init__(self, numpy=False) -> None:
-        self.numpy = numpy
-
-        super().__init__()
-
-    def get_col_spec(self, **kw):
-        return "CUBE"
-
-    def bind_processor(self, dialect):
-        def process(value):
-            return ",".join(str(v) for v in value)
-
-        return process
-
-    def result_processor(self, dialect, coltype):
-
-        if self.numpy:
-            import numpy as np
-
-            def process_numpy(value):
-                if isinstance(value, memoryview):
-                    value = value.tobytes()
-
-                return np.fromstring(value[1:-1], sep=",")
-
-            return process_numpy
-
-        def process_tuple(value):
-            if isinstance(value, memoryview):
-                value = value.tobytes()
-                sep = b","
-            else:
-                sep = ","
-
-            return tuple(float(v) for v in value[1:-1].split(sep))
-
-        return process_tuple
-
-    class Comparator(TypeEngine.Comparator):
-        def dist_euclidean(self, other):
-            return self.op("<->", return_type=Float)(other)
-
-    comparator_factory = Comparator
-
+from morphocluster.sql.types import Point
 
 metadata = db.metadata
 

--- a/morphocluster/sql/types.py
+++ b/morphocluster/sql/types.py
@@ -1,0 +1,55 @@
+from sqlalchemy.types import TypeEngine, UserDefinedType, Float
+
+
+class Point(UserDefinedType):
+    """
+    Represent a point by using a zero-volume cube from the cube extension.
+
+    This allows to calculate distances inside the database.
+
+    https://www.postgresql.org/docs/current/cube.html
+    """
+
+    def __init__(self, numpy=False) -> None:
+        self.numpy = numpy
+
+        super().__init__()
+
+    def get_col_spec(self, **kw):
+        return "CUBE"
+
+    def bind_processor(self, dialect):
+        def process(value):
+            return ",".join(str(v) for v in value)
+
+        return process
+
+    def result_processor(self, dialect, coltype):
+
+        if self.numpy:
+            import numpy as np
+
+            def process_numpy(value):
+                if isinstance(value, memoryview):
+                    value = value.tobytes()
+
+                return np.fromstring(value[1:-1], sep=",")
+
+            return process_numpy
+
+        def process_tuple(value):
+            if isinstance(value, memoryview):
+                value = value.tobytes()
+                sep = b","
+            else:
+                sep = ","
+
+            return tuple(float(v) for v in value[1:-1].split(sep))
+
+        return process_tuple
+
+    class Comparator(TypeEngine.Comparator):
+        def dist_euclidean(self, other):
+            return self.op("<->", return_type=Float)(other)
+
+    comparator_factory = Comparator


### PR DESCRIPTION
Object vectors are stored as CUBE points. Distances to the centroid of a cluster can than be calculated without transferring the vector to the web application.

- [ ] Python
  - [ ] tests coverage
  - [ ] tests pass
  - [ ] passes `black pandas`
  - [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] JavaScript
  - [ ] Builds
- [x] Successful manual test
