### PR TITLE
Recluster explorative 2.0.x

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Current (0.2.x)
 ==================
 
+0.2.1
+=====
+
+- Make clustering more explorative by removing a fraction of the dataset that is closest to already validated clusters (#72)
+
 0.2.0
 =====
 

--- a/morphocluster/scripts.py
+++ b/morphocluster/scripts.py
@@ -162,6 +162,7 @@ def features(archive_fn, output_fn, parameters_fn, normalize, batch_size, input_
 @click.option("--sample-size", type=int, default=None)
 @click.option("--pca", type=int, default=None)
 @click.option("--init-tree/--no-init-tree", help="Initialize tree from dataset.")
+@click.option("--keep-unexplored", type=float, default=None)
 def cluster(
     features_fns,
     result_fn,
@@ -172,6 +173,7 @@ def cluster(
     sample_size,
     pca,
     init_tree: bool,
+    keep_unexplored: Optional[float]
 ):
     rc = Recluster()
 
@@ -190,6 +192,7 @@ def cluster(
         cluster_selection_method=method,
         sample_size=sample_size,
         pca=pca,
+        keep_unexplored=keep_unexplored,
     )
 
     rc.save(result_fn)


### PR DESCRIPTION
Closes #xxxx

- [ ] Python
  - [ ] tests coverage
  - [ ] tests pass
  - [ ] passes `black pandas`
  - [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] JavaScript
  - [ ] Builds
- [x] Successful manual test
- [x] Changelog
